### PR TITLE
fixed send_text() not sending text with urls

### DIFF
--- a/main.py
+++ b/main.py
@@ -348,11 +348,15 @@ def send_ordercost_prompt(id, price):
     resp = requests.post(url, params=mes_params)
     return resp.content
 
+def get_rid_of_protocol(url: str):
+    url = re.sub(r'http[s]?://', '', url)
+    return url
+
 def send_text(id, text="Test"):
     mes_params = {
 	"chat_id": id,
 	"parse_mode": "markdown",
-	"text": text
+	"text": get_rid_of_protocol(text)
 	}
     resp = requests.post(url, params=mes_params)
     return resp.content


### PR DESCRIPTION
fixed send_text() by deleting the protocol part of url, so it sends properly